### PR TITLE
Custom jdk_11.0.16_8 installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,22 @@ RUN apt-get update && apt-get install -y curl rsync wget
 
 WORKDIR /opt/java
 
+RUN mkdir -p /usr/lib/jvm
+
 RUN wget https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u275-b01/OpenJDK8U-jdk_x64_linux_8u275b01.tar.gz
 
 RUN tar -xzf OpenJDK8U-jdk_x64_linux_8u275b01.tar.gz
 
-RUN mkdir -p /usr/lib/jvm
-
 RUN ln -s /opt/java/openjdk-8u275-b01 /usr/lib/jvm/jdkredhat-openjdk-1.8.0.275
 
 RUN rm -f OpenJDK8U-jdk_x64_linux_8u275b01.tar.gz
+
+RUN wget https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.16%2B8/OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
+
+RUN tar -xzf OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
+
+RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
+
+RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
 USER jenkins


### PR DESCRIPTION
As SonarQube 9.x requires that the scanner be run using Java 11, we will need Java 11 on the ecs-spot-jdk8 agent label to support projects that use this agent and also run the sonarqube task.  Projects to be scanned can still be built using Java 8.

This is like step 3 in a 60 step process to rollout SonarQube 9.x, but there's no reason not to get ahead of it.