### PR TITLE
ENGOPS-3608 Adding Java_Home variable to the file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
 
 RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
-RUN sed '2 i JAVA_HOME=/usr/lib/jvm/openjdk-11.0.16_8' /usr/local/bin/jenkins-agent > /usr/local/bin/jenkins-agent-java11
+RUN sed 's+$JAVA_BIN $JAVA_OPTS+/usr/lib/jvm/openjdk-11.0.16_8/bin/java $JAVA_OPTS+g' /usr/local/bin/jenkins-agent > /usr/local/bin/jenkins-agent-java11
 
 RUN chmod +x /usr/local/bin/jenkins-agent-java11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
 
 RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
-sed -i '2 i JAVA_HOME=/usr/lib/jvm/openjdk-11.0.16_8' /usr/local/bin/jenkins-agent
+Run sed -i '2 i JAVA_HOME=/usr/lib/jvm/openjdk-11.0.16_8' /usr/local/bin/jenkins-agent
 
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
 
 RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
-RUN sed -i 's+$JAVA_BIN $JAVA_OPTS+/usr/lib/jvm/openjdk-11.0.16_8/bin/java $JAVA_OPTS+g' /usr/local/bin/jenkins-agent
+RUN sed '2 i JAVA_HOME=/usr/lib/jvm/openjdk-11.0.16_8' /usr/local/bin/jenkins-agent > /usr/local/bin/jenkins-agent-java11
+
+RUN chmod +x /usr/local/bin/jenkins-agent-java11
 
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,6 @@ RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
 
 RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
+RUN sed -i 's+$JAVA_BIN $JAVA_OPTS+/usr/lib/jvm/openjdk-11.0.16_8/bin/java $JAVA_OPTS+g' /usr/local/bin/jenkins-agent
+
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
 
 RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
-RUN sed -i 's+$JAVA_BIN $JAVA_OPTS+/usr/lib/jvm/openjdk-11.0.16_8/bin/java $JAVA_OPTS+g'
+RUN sed -i 's+$JAVA_BIN $JAVA_OPTS+/usr/lib/jvm/openjdk-11.0.16_8/bin/java $JAVA_OPTS+g' /usr/local/bin/jenkins-agent
 
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:3107.v665000b_51092-15-jdk11
+FROM jenkins/inbound-agent:4.9-1
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
 
 RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
-Run sed -i '2 i JAVA_HOME=/usr/lib/jvm/openjdk-11.0.16_8' /usr/local/bin/jenkins-agent
+RUN sed -i 's+$JAVA_BIN $JAVA_OPTS+/usr/lib/jvm/openjdk-11.0.16_8/bin/java $JAVA_OPTS+g'
 
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,6 @@ RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
 
 RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
+sed -i '2 i JAVA_HOME=/usr/lib/jvm/openjdk-11.0.16_8' /usr/local/bin/jenkins-agent
+
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,4 @@ RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
 
 RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
-RUN sed -i 's+$JAVA_BIN $JAVA_OPTS+/usr/lib/jvm/openjdk-11.0.16_8/bin/java $JAVA_OPTS+g' /usr/local/bin/jenkins-agent
-
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:4.9-1
+FROM jenkins/inbound-agent:3107.v665000b_51092-15-jdk11
 
 USER root
 


### PR DESCRIPTION
So we are trying to upgrade jenkins from Jenkins 2.332.3 to Jenkins 2.387.1.
The default Jenkins version works on Java 8 and newer version requires Java 11 or 17. So in order to make our ecs agents working in the new environment,we decided to update docker files by creating a new executable /usr/local/bin/jenkins-agent-java11 on the agent image, which we plugged into ENTRYPOINT OVERRIDE in the Jenkins config, to make the image support both Java 8 (current) Jenkins and Java 11 (upgraded) Jenkins.