### PR TITLE
ENGOPS-4368 add java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,14 @@ RUN ln -s /opt/java/openjdk-11.0.16_8 /usr/lib/jvm/openjdk-11.0.16_8
 
 RUN rm -f OpenJDK11U-jdk_x64_linux_11.0.16_8.tar.gz
 
+RUN wget https://download.oracle.com/java/17/archive/jdk-17.0.9_linux-x64_bin.tar.gz
+
+RUN tar -xzf jdk-17.0.9_linux-x64_bin.tar.gz
+
+RUN ln -s /opt/java/jdk-17.0.9 /usr/lib/jvm/openjdk-17
+
+RUN rm -f jdk-17.0.9_linux-x64_bin.tar.gz
+
 RUN sed 's+$JAVA_BIN $JAVA_OPTS+/usr/lib/jvm/openjdk-11.0.16_8/bin/java $JAVA_OPTS+g' /usr/local/bin/jenkins-agent > /usr/local/bin/jenkins-agent-java11
 
 RUN chmod +x /usr/local/bin/jenkins-agent-java11


### PR DESCRIPTION
We're going to need Java 17 on this agent at some point to support PTE snapshot publishing once the Java 17 epic merges... so let's get this in there now.